### PR TITLE
Use a stable version of junit

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,10 +18,10 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
-        <groupId>junit</groupId>
-        <artifactId>junit</artifactId>
-        <version>4.13-beta-3</version>
-        <scope>test</scope>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.8.2</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.diffblue</groupId>


### PR DESCRIPTION
We might run into issues using a beta version of Junit so I've downgraded it to the mininmum required version for Cover Intellij plugin. 